### PR TITLE
記事に関するAPIのルーティングの実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      resources :articles
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
-  namespace :api do
+  namespace :api, format: "json" do
     namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
       resources :articles
     end
   end


### PR DESCRIPTION
## 作業内容
articleに関するAPIのendpointが/api/v1 から始まるようroutes.rbを修正

## 参考にした情報
https://railsguides.jp/routing.html#%E3%82%B3%E3%83%B3%E3%83%88%E3%83%AD%E3%83%BC%E3%83%A9%E3%81%AE%E5%90%8D%E5%89%8D%E7%A9%BA%E9%96%93%E3%81%A8%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0