### PR TITLE
記事作成APIの実装

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::ApiController < ApplicationController
+  def current_user
+    @current_user = User.first
+  end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,4 +8,14 @@ class Api::V1::ArticlesController < Api::V1::ApiController
     article = Article.find(params[:id])
     render json: article
   end
+
+  def create
+    article = current_user.articles.create!(article_params)
+    render json: article
+  end
+
+  private
+    def article_params
+      params.require(:article).permit(:title, :body)
+    end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,6 +15,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   end
 
   private
+
     def article_params
       params.require(:article).permit(:title, :body)
     end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
 
-
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params) }
-    let(:params) {{ article: attributes_for(:article) }}
+
+    let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
 
     before do
@@ -67,7 +67,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       res = JSON.parse(response.body)
       expect(res["title"]).to eq params[:article][:title]
       expect(res["body"]).to eq params[:article][:body]
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -51,4 +51,23 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+
+  describe "POST /api/v1/articles" do
+    subject { post(api_v1_articles_path, params: params) }
+    let(:params) {{ article: attributes_for(:article) }}
+    let(:current_user) { create(:user) }
+
+    before do
+      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
+    end
+
+    it "記事が作成できる" do
+      expect { subject }.to change { current_user.articles.count }.by(1)
+      res = JSON.parse(response.body)
+      expect(res["title"]).to eq params[:article][:title]
+      expect(res["body"]).to eq params[:article][:body]
+      expect(response).to have_http_status(200)
+    end
+  end
 end


### PR DESCRIPTION
## 作業内容
Api::V1::ArticlesControllerにcreateアクションを定義し、テストを実装。
テストの実装に際しては、currrent_userについてスタブを使用。

## 留意事項
Api::V1::ApiControllerに、仮実装として、current_userをusers テーブルの一番初めのユーザーとするメソッドを定義。
