### PR TITLE
ログイン API の実装

### DIFF
--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,11 +1,2 @@
 class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
-  # def params_for_resource(resource)
-  #   binding.pry
-  # end
-
-
-
-  def create
-    binding.pry
-  end
 end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
+  # def params_for_resource(resource)
+  #   binding.pry
+  # end
+
+
+
+  def create
+    binding.pry
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,5 +15,4 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   # gem deviseにおいて定義されているemailのformat @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,5 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   # gem deviseにおいて定義されているemailのformat @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
-  validates :password, presence: true
-  # gem deviseにおいて定義されているpassword_length @@password_length = 6..128
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
-        sessions:  "api/v1/auth/sessions"
+        sessions: "api/v1/auth/sessions",
       }
       resources :articles
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
+        sessions:  "api/v1/auth/sessions"
       }
       resources :articles
     end

--- a/db/migrate/20200119021717_add_trackable_fields_to_users.rb
+++ b/db/migrate/20200119021717_add_trackable_fields_to_users.rb
@@ -1,0 +1,11 @@
+class AddTrackableFieldsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_table :users do |t|
+      t.integer :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_03_010503) do
+ActiveRecord::Schema.define(version: 2020_01_19_021717) do
 
   create_table "article_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "body"
@@ -58,6 +58,11 @@ ActiveRecord::Schema.define(version: 2020_01_03_010503) do
     t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 作業内容
- Userテーブルにtrackable関連カラムを追加。
- DeviseTokenAuth::SessionsControllerを継承するApi::V1::Auth::SessionsControllerを作成し、ルーティングを設定。
- User modelのpasswordに関するvalidationを削除（gem devise_token_authに同様の機能があり、役割が重複するため）。

## 参考にした情報
https://stackoverflow.com/questions/55735895/nomethoderror-undefined-method-current-sign-in-at-for-user0x000055ce01dcf0a
https://qiita.com/yuknak/items/c946b642a64d89fd9f59