### PR TITLE
deviseのhelper method使用に係る既存API の修正

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::ApiController < ApplicationController
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,5 +1,2 @@
 class Api::V1::ApiController < ApplicationController
-  def current_user
-    @current_user = User.first
-  end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
+
   def index
     articles = Article.all
     render json: articles

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -53,14 +53,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事が作成できる" do
       expect { subject }.to change { current_user.articles.count }.by(1)
@@ -72,14 +69,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: { body: Faker::Quote.matz, created_at: Time.current } } }
     let(:current_user) { create(:user) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers) { current_user.create_new_auth_token }
 
     describe "正常系のテスト" do
       context "自身の作成記事を更新しようとする場合" do
@@ -106,13 +100,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers) { current_user.create_new_auth_token }
 
     describe "正常系のテスト" do
       context "自身の作成記事を削除しようとする場合" do


### PR DESCRIPTION
## 作業内容
- api_controllerのダミーコードcurrent_userメソッドを削除
- api_controllerにdeviseのhelper methodのalias methodを作成
- article_controllerにbefore _action authenticate_user! を設置
- article_apiのテストをヘッダー情報を用いてログインするように変更

## 参考にした情報
https://ref.xaio.jp/ruby/classes/module/alias_method