### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,4 +5,6 @@ class Article < ApplicationRecord
 
   validates :title, presence: true
   validates :body, presence: true
+
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20200205002917_add_status_to_articles.rb
+++ b/db/migrate/20200205002917_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_19_021717) do
+ActiveRecord::Schema.define(version: 2020_02_05_002917) do
 
   create_table "article_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "body"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2020_01_19_021717) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :article do
     title { Faker::Movie.quote }
     body { Faker::Quote.matz }
+    status { :draft }
     user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,6 +8,38 @@ RSpec.describe Article, type: :model do
         expect(article).to be_valid
       end
     end
+
+    describe "statusを指定した記事の取得" do
+      describe "下書き記事の取得" do
+        subject { Article.draft }
+
+        context "statusが下書きである記事があるとき" do
+          before do
+            create_list(:article, 5)
+          end
+
+          it "下書き記事が取得できる" do
+            expect(subject.count).to eq 5
+            expect(subject[0].status).to eq "draft"
+          end
+        end
+      end
+
+      describe "公開記事の取得" do
+        subject { Article.published }
+
+        context "statusが公開である記事があるとき" do
+          before do
+            create_list(:article, 10, status: "published")
+          end
+
+          it "公開記事が取得できる" do
+            expect(subject.count).to eq 10
+            expect(subject[0].status).to eq "published"
+          end
+        end
+      end
+    end
   end
 
   describe "異常系のテスト" do


### PR DESCRIPTION
## 作業内容
- Articlesテーブルにstatusカラムを追加し、同カラムに対応するenumをモデルに追加。
- statusを指定した記事取得に関するテストを実装

## 参考にした情報
https://qiita.com/clbcl226/items/3e832603060282ddb4fd
https://doruby.jp/users/ishizu/entries/enum%E3%81%A7%E6%95%B0%E5%80%A4%E5%9E%8B%E3%82%AB%E3%83%A9%E3%83%A0%E3%82%92%E4%BD%9C%E3%82%8B%E9%9A%9B%E3%81%AB%E3%80%81%E3%83%86%E3%82%B9%E3%83%88%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92%E4%BD%9C%E3%82%8B%E6%99%82%E3%81%AB%E6%B3%A8%E6%84%8F%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8