### PR TITLE
下書き機能追加に伴う既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   private
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 
     def set_article_of_current_user

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,12 +2,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.all
+    articles = Article.published
     render json: articles
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article
   end
 

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,5 +1,5 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user
   # user model の一部の属性のみ返したいため
   class UserSerializer < ActiveModel::Serializer


### PR DESCRIPTION
- 公開記事だけ取得できるように、controllerを修正
- 記事作成時のパラメーターにstatus（公開or下書き）を追加
- テストの修正
